### PR TITLE
Update toolchain to use Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+
+ARG METABASE_VERSION=v0.42.0-preview1
+
+FROM clojure:openjdk-11-tools-deps-slim-buster AS stg_base
+
+# Reequirements for building the driver
+RUN apt-get update && \
+    apt-get install -y \
+    curl \
+    make \
+    unzip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set our base workdir
+WORKDIR /build
+
+# We need to retrieve metabase source
+# Due to how ARG and FROM interact, we need to re-use the same ARG
+# Ref: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG METABASE_VERSION
+RUN curl -Lo - https://github.com/metabase/metabase/archive/refs/tags/${METABASE_VERSION}.tar.gz | tar -xz \
+    && mv metabase-* metabase
+
+# Driver source goes inside metabase source so we can use their build scripts
+WORKDIR /build/driver
+
+# Copy our project assets over
+COPY deps.edn ./
+COPY src/ ./src
+COPY resources/ ./resources
+
+# Then prep our Metabase dependencies
+# We need to build java deps and then spark-sql deps
+# Ref: https://github.com/metabase/metabase/wiki/Migrating-from-Leiningen-to-tools.deps#preparing-dependencies
+WORKDIR /build/metabase
+RUN --mount=type=cache,target=/root/.m2/repository \
+    clojure -X:deps prep
+
+WORKDIR /build/metabase/modules/drivers
+RUN --mount=type=cache,target=/root/.m2/repository \
+    clojure -X:deps prep
+WORKDIR /build/driver
+
+# Test stage (but no tests yet :()
+# FROM stg_base as stg_test
+# COPY test_unit/ ./test_unit
+# RUN clojure -X:test:deps prep
+# # Some dependencies still get downloaded when the command below is run, but I'm not sure why
+# CMD ["clojure", "-X:test"]
+
+# Now build the driver
+FROM stg_base as stg_build
+RUN --mount=type=cache,target=/root/.m2/repository \
+    clojure -X:dev:build
+
+# We create an export stage to make it easy to export the driver
+FROM scratch as stg_export
+COPY --from=stg_build /build/driver/target/trino.metabase-driver.jar /
+
+# Now we can run Metabase with our built driver
+FROM metabase/metabase:${METABASE_VERSION} AS stg_runner
+
+# A metabase user/group is manually added in https://github.com/metabase/metabase/blob/master/bin/docker/run_metabase.sh
+# Make the UID and GID match
+COPY --chown=2000:2000 --from=stg_build \
+    /build/driver/target/trino.metabase-driver.jar \
+    /plugins/trino.metabase-driver.jar

--- a/README.md
+++ b/README.md
@@ -2,40 +2,31 @@
 
 An example for how to implement a Trino driver based off existing Presto JDBC support in Metabase.
 
-_Please note this only supports the latest unstable version of Metabase until v0.41 is released_
+_Please note this only supports `v0.42.0-preview1` version of Metabase until v0.42 is released_
 
 _This is also just an example of how to implement this - I DO NOT plan on supporting a Trino driver. :)_
 
 ## Prerequisites
 
-The next version of Metabase [changes how plugins](https://github.com/metabase/metabase/pull/17606) are built. You'll need to use the latest branch.
+- Docker
+
+## Run Metabase
+
+If you just want to run the 0.42 preview release of Metabase with this driver, just do a `docker build` and `run`.
 
 ```shell
-git clone https://github.com/metabase/metabase.git
+docker build -t metabase/trino .
+docker run --rm --name metabase-trino -p 3000:3000 metabase/trino
 ```
 
-## Compiling
+This will load up Metabase on port 3000 with the Trino driver loaded up.
 
-- Update `deps.cdn`
+### Build Jars
 
-For some reason, absolute paths are necessary in this file, so you'll have to update it with the path as necessary.
-
-- Build the plugin
+If you want the Trino jar to copy to your own Metabase intallation, you can use the `--output` flag with `docker build`.
 
 ```shell
-clojure -X:dev:build
+docker build --output jars --target stg_export .
 ```
 
-- Copy the resulting drive to wherever you have Metabase checked out
-
-```shell
-cp target/trino.metabase-driver.jar ../metabase/plugins/
-```
-
-## Running
-
-- Spin up the latest development branch of Metabase:
-
-```
-clojure -M:run:drivers
-```
+If successful, you should have a `jars/trino.metabase-driver.jar` file.

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths
- ["/Users/username/src/metabase-trino-driver/src" "/Users/username/src/metabase-trino-driver/resources"]
+ ["/build/driver/src" "/build/driver/resources"]
 
  :deps
  {io.trino/trino-jdbc {:mvn/version "361"}}
@@ -7,8 +7,8 @@
  ;; build the driver with clojure -X:build
  :aliases
  {:build
-  {:extra-deps {metabase/metabase-core {:local/root "../../mbsrc/metabase"}
-                metabase/build-drivers {:local/root "../../mbsrc/metabase/bin/build-drivers"}}
+  {:extra-deps {metabase/metabase-core {:local/root "../metabase"}
+                metabase/build-drivers {:local/root "../metabase/bin/build-drivers"}}
    :exec-fn    build-drivers.build-driver/build-driver!
    :exec-args  {:driver      :trino
                 :project-dir "."


### PR DESCRIPTION
Adds a Dockerfile that allows you to build and run Metabase with the jar pre-installed or just build the jar.